### PR TITLE
fix: adding ploidy 1 flag and bcftools command corrections

### DIFF
--- a/Bioinformatics_8/run_bcftools.sh
+++ b/Bioinformatics_8/run_bcftools.sh
@@ -13,10 +13,11 @@ m="$a.bam $m"
 done
 
 VCF=Salmonella.vcf.gz
-VCFFILTER=Salmonella.filtered.vcf.gz
+FILTERED=Salmonella.filtered.vcf.gz
+LOWQUAL="FAIL"
 bcftools mpileup -Ou -f $GENOME $m | bcftools call --ploidy 1 -vmO z -o $VCF
 tabix -p vcf $VCF
 bcftools stats -v -F $GENOME -s - $VCF > $VCF.stats
 mkdir -p plots
 plot-vcfstats -p plots/ $VCF.stats
-bcftools filter -O z -o $FILTERED -s LOWQUAL -i'%QUAL>10' $VCF
+bcftools filter -O z -o $FILTERED -s $LOWQUAL -i'%QUAL>10' $VCF

--- a/Bioinformatics_8/run_bcftools.sh
+++ b/Bioinformatics_8/run_bcftools.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/bash
 #SBATCH -p batch -N 1 -n 4 --mem 16gb
 module unload perl
 module load samtools
@@ -13,9 +14,9 @@ done
 
 VCF=Salmonella.vcf.gz
 VCFFILTER=Salmonella.filtered.vcf.gz
-bcftools mpileup -Ou -f $GENOME $m | bcftools call -vmO z -o $VCF
+bcftools mpileup -Ou -f $GENOME $m | bcftools call --ploidy 1 -vmO z -o $VCF
 tabix -p vcf $VCF
-bcftools stats -F $GENOME -s - $VCF $VCF.stats
+bcftools stats -v -F $GENOME -s - $VCF > $VCF.stats
 mkdir -p plots
 plot-vcfstats -p plots/ $VCF.stats
 bcftools filter -O z -o $FILTERED -s LOWQUAL -i'%QUAL>10' $VCF


### PR DESCRIPTION
@hyphaltip these changes got me to creating the plotly .pdf and there's one outstanding error:
```
$ cat slurm-2551140.out 
[mpileup] 1 samples in 1 input files
[mpileup] maximum number of reads per input file set to -d 250
Parsing bcftools stats output: Salmonella.vcf.gz.stats
Plotting graphs: python3 plot.py
Creating PDF: pdflatex summary.tex >plot-vcfstats.log 2>&1
Finished: plots//summary.pdf
[E::hts_open_format] Failed to open file "LOWQUAL" : No such file or directory
Failed to read from LOWQUAL: No such file or directory
```

Update re: "LOWQUAL" error: I think this is what you meant to do?: https://github.com/biodataprog/GEN220_2019_examples/pull/2/commits/aa2717b80400ddec675af43c73c509696536363a